### PR TITLE
fix(frontend): Fix QR code not displaying on login page (Bug #29)

### DIFF
--- a/platform/frontend/src/services/auth.ts
+++ b/platform/frontend/src/services/auth.ts
@@ -60,7 +60,9 @@ export class AuthService {
       throw new Error(error.message || '获取授权 URL 失败');
     }
 
-    return response.json();
+    const result = await response.json();
+    // 后端返回格式: { success: true, data: { url: "...", platform: "..." } }
+    return result.data || result;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR fixes Bug #29 where the DingTalk/Feishu QR code was not displaying on the /login page, even though the API returned the correct authorization URL.

## Problem

**Symptom**:
- Users access `/login` page
- Select DingTalk or Feishu platform
- API call succeeds (200 status code)
- But QR code doesn't display
- No console errors

**API Response** (correct):
```json
{
  "success": true,
  "data": {
    "url": "https://login.dingtalk.com/oauth2/auth?...",
    "platform": "dingtalk"
  }
}
```

## Root Cause

**Data structure mismatch** between backend response and frontend parsing:

Backend returns:
```json
{ "success": true, "data": { "url": "...", "platform": "..." } }
```

Frontend code expects:
```typescript
const data = await authService.getAuthorizationUrl(platform);
setQrCodeUrl(data.url);  // Expects data.url to exist
```

But `getAuthorizationUrl()` returns:
```typescript
return response.json();  // Returns { success: true, data: { url: "...", platform: "..." } }
```

Result: `data.url` is `undefined` → QR code doesn't render

## Solution

**Fixed** `getAuthorizationUrl()` to extract `data.url` from backend response:

```typescript
// Before:
return response.json();

// After:
const result = await response.json();
// 后端返回格式: { success: true, data: { url: "...", platform: "..." } }
return result.data || result;
```

This is the **same fix pattern** as Bug #1 (getEnabledPlatforms issue).

## Changes

**Modified Files**:
- `platform/frontend/src/services/auth.ts` (lines 63-65)

## Testing

After deployment, verify:
1. ✅ Access http://113.105.103.165:20180/login
2. ✅ Select DingTalk or Feishu platform
3. ✅ QR code displays correctly
4. ✅ Console has no errors
5. ✅ OAuth flow completes successfully

## Related Issues

- Fixes: Bug #29 - QR code not displaying
- Related: Bug #1 (same issue with getEnabledPlatforms)
- Related: PR #27 (environment variable fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>