### PR TITLE
chore(ci): Disable auto-triggering GitHub Actions workflows

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -1,16 +1,6 @@
 name: Backend E2E Tests
 
 on:
-  push:
-    branches: [main, develop]
-    paths:
-      - 'platform/backend/**'
-      - '.github/workflows/backend-e2e-tests.yml'
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'platform/backend/**'
-      - '.github/workflows/backend-e2e-tests.yml'
   workflow_dispatch:
     inputs:
       run_specific_scenario:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI Pipeline
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_dispatch:
 
 # Cancel in-progress runs for the same branch and workflow
 concurrency:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,10 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,9 +1,7 @@
 name: PR Check
 
 on:
-  pull_request:
-    branches: [ main, develop ]
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 # Cancel in-progress runs for the same branch and workflow
 concurrency:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,10 +1,7 @@
 name: Quality Gate
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_dispatch:
 
 jobs:
   quality-gate:

--- a/.github/workflows/test-rollback.yml
+++ b/.github/workflows/test-rollback.yml
@@ -21,10 +21,6 @@ name: 回滚验证测试 (Rollback Verification Test)
 #==============================================================================
 
 on:
-  # 定时执行 - 每周日凌晨 3 点
-  schedule:
-    - cron: '0 3 * * 0'
-
   # 手动触发
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- 将 6 个自动触发的 GitHub Actions workflow 全部改为仅手动触发 (`workflow_dispatch`)
- 涉及: `ci`, `pr-check`, `e2e-tests`, `backend-e2e-tests`, `quality-gate`, `test-rollback`
- 所有 workflow 文件保留，需要时可手动运行

## Test plan
- [ ] 确认合并后 GitHub Actions 页面不再自动运行 workflow
- [ ] 确认各 workflow 仍可手动触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)